### PR TITLE
Fixing problem with rating change not being equal

### DIFF
--- a/lib/elo/rating.rb
+++ b/lib/elo/rating.rb
@@ -50,7 +50,7 @@ module Elo
 		# For more information visit
 		# {Wikipedia}[http://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details]
     def change
-      k_factor.to_f * ( result.to_f - expected )
+      (k_factor.to_f * ( result.to_i - expected )).to_i
     end
 
 

--- a/spec/elo_spec.rb
+++ b/spec/elo_spec.rb
@@ -41,6 +41,16 @@ describe "Elo" do
 
   end
 
+  #from Wikipedia: The winner of a contest between two players gains a certain number of points in his rating and the losing player loses the same amount.
+  it "rating change should be the same" do
+    bob = Elo::Player.new :rating => 1000
+    jane = Elo::Player.new :rating => 1000
+
+    game1 = bob.wins_from(jane)
+
+    (1000 - jane.rating).should == (bob.rating - 1000)
+  end
+
   describe "Configuration" do
 
     it "default_rating" do


### PR DESCRIPTION
There's a problem with matches where they don't necessarily have the same change (with 2 players the same rating)

This breaks other specs though and I'm not sure how the expectations were generated.
