### PR TITLE
Don't round ratings!

### DIFF
--- a/lib/elo/rating.rb
+++ b/lib/elo/rating.rb
@@ -19,7 +19,7 @@ module Elo
 
 		# The new rating is... wait for it... the new rating!
     def new_rating
-      (old_rating.to_f + change).to_i
+      old_rating.to_f + change
     end
 
 		private


### PR DESCRIPTION
By truncating ratings with `to_i`, the system was effectively suffering from entropy:

Before this pull request:

```
a = Elo::Player.new(rating: 1000)
b = Elo::Player.new(rating: 1000)

a.wins_from(b)

a.rating # 1012
b.rating # 987

a.rating + b.rating # 1999, SHOULD be 2000

10000.times { a.wins_from(b) }
a.rating # 1197
b.rating # 0
```

After this pull request we're subject to rounding errors from floating point, but at least we're not throwing away entire points on every game:

```
a = Elo::Player.new(rating: 1000)
b = Elo::Player.new(rating: 1000)

a.wins_from(b)

a.rating # 1012.5
b.rating # 987.5

a.rating + b.rating # 2000.0
```
