### PR TITLE
to_f used instead of to_i in New Rating method

### DIFF
--- a/lib/elo/rating.rb
+++ b/lib/elo/rating.rb
@@ -19,7 +19,7 @@ module Elo
 
 		# The new rating is... wait for it... the new rating!
     def new_rating
-      (old_rating.to_f + change).to_i
+      (old_rating.to_f + change).to_f
     end
 
 		private
@@ -38,7 +38,7 @@ module Elo
 
 		# The expected score is the probably outcome of the match, depending
 		# on the difference in rating between the two players.
-		# 
+		#
 		# For more information visit
 		# {Wikipedia}[http://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details]
     def expected
@@ -46,7 +46,7 @@ module Elo
     end
 
 		# The change is the points you earn or lose.
-		# 
+		#
 		# For more information visit
 		# {Wikipedia}[http://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details]
     def change


### PR DESCRIPTION
As Elo is used in  zero-sum games in which each participant's gain or loss of utility is exactly balanced by the losses or gains of the utility of the other participants.
#to_i here remove that precision from new rating (e.g. where one player is gaining 13 and other is loosing 12).

In few matches it does not affect much but if there are large number of matches between 2 players then these small loss precision affects the rating.

In my case i started with 2 player with rating 1000 each and ran a script for 1000 matches between them with random output.

In Case of #to_i.
player1 rating drops to 525
player2 rating drops to 476

In Case of #to_f
player1 rating increase to 1013.3827387
player2 rating drops to 986.6172

here in second case it actually proving the zero-sum Games logic.

