### PR TITLE
Round new_rating instead of flooring

### DIFF
--- a/lib/elo/rating.rb
+++ b/lib/elo/rating.rb
@@ -19,7 +19,7 @@ module Elo
 
 		# The new rating is... wait for it... the new rating!
     def new_rating
-      (old_rating.to_f + change).to_i
+      (old_rating.to_f + change).round
     end
 
 		private
@@ -38,7 +38,7 @@ module Elo
 
 		# The expected score is the probably outcome of the match, depending
 		# on the difference in rating between the two players.
-		# 
+		#
 		# For more information visit
 		# {Wikipedia}[http://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details]
     def expected
@@ -46,7 +46,7 @@ module Elo
     end
 
 		# The change is the points you earn or lose.
-		# 
+		#
 		# For more information visit
 		# {Wikipedia}[http://en.wikipedia.org/wiki/Elo_rating_system#Mathematical_details]
     def change


### PR DESCRIPTION
Using `.to_i` here will floor the result. Using `.round` over time will be more accurate. There are other PRs that change the output of the library to be a float, which works as well; however, there may be applications using this library expecting an integer.